### PR TITLE
disable some simd instructions for iSH build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.i686-unknown-linux-musl]
+rustflags = ["-Ctarget-feature=-avx2,-sse,-sse2"]


### PR DESCRIPTION
we get a segfault now but no more `Illegal instruction`